### PR TITLE
fix order_by creation in get_item_quality_specification

### DIFF
--- a/lpp_co/custom/item.py
+++ b/lpp_co/custom/item.py
@@ -15,12 +15,13 @@ def get_item_quality_specification(item_group):
 		"Quality Inspection Parameter",
 		filters=[
 			["Quality Inspection Parameter Item Group",
-				"item_group", "in", item_groups]
+				"item_group", "in", item_groups],
+			["custom_is_item_spec", "=", 1]
 		],
 		pluck="name",
-		order_by="name"
+		order_by="`tabQuality Inspection Parameter`.`creation` asc"  
 	)
-	return list(set(params))
+	return list(dict.fromkeys(params))
 
 
 def validate_item_specification_line(doc, method):


### PR DESCRIPTION
แก้ไขให้เมื่อกดปุ่ม Reset Quality Parameters แล้วระบบคัด Parameters มาเฉพาะที่
1. Related Item Group
2. Is Item Spec
3. เรียง Parameters ตามกัน แบบที่เรียงใน Master Data