### PR TITLE
allow selecting the same production_item multiple times in Job Card

### DIFF
--- a/lpp_co/custom/quality_inspection.py
+++ b/lpp_co/custom/quality_inspection.py
@@ -192,12 +192,14 @@ def item_query(doctype, txt, searchfield, start, page_len, filters):
 		)
 
 	elif filters.get("reference_name"):
+		conditions = "" if from_doctype == "Job Card" else f"{qi_condition} {cond} {mcond}"
+		
 		return frappe.db.sql(
 			f"""
 				SELECT production_item
 				FROM `tab{from_doctype}`
 				WHERE name = %(reference_name)s and docstatus < 2 and production_item like %(txt)s
-				{qi_condition} {cond} {mcond}
+				{conditions}
 				ORDER BY production_item
 				limit {cint(page_len)} offset {cint(start)}
 			""",


### PR DESCRIPTION
ปรับปรุง logic ของ item_query เพื่อให้สามารถเลือก production_item ซ้ำได้ เมื่อ Doctype ต้นทางคือ Job Card เดิมระบบบังคับใช้ qi_condition (ต้องไม่มี Quality Inspection) ทำให้ไม่สามารถเลือก Item เดิมซ้ำได้หากเคยถูกใช้ไปแล้ว แต่ในกรณีการทำงานของ Job Card ผู้ใช้งานมักต้องสร้าง Quality Inspection หลายครั้งสำหรับ production_item เดิม